### PR TITLE
display: Disable EGL buffer_age extension support

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -23,6 +23,7 @@ media.stagefright.less-secure=true
 ro.sf.lcd_density=480
 persist.hwc.mdpcomp.enable=true
 ro.opengles.version=196608
+debug.hwui.use_buffer_age=false
 
 # GPS
 persist.gps.qc_nlp_in_use=0


### PR DESCRIPTION
 * Due to commit I9b346b4053ec12c8a78a143a4dc0e708c44888a2
    "Support EGL_KHR_partial_update without EGL_EXT_buffer_age"
    in libhwui, EGL_EXT_buffer_age extension was forcibly enabled
    if EGL_KHR_partial_update was available, even if the EGL driver
    was not providing EGL_EXT_buffer_age support

 * On older Adreno drivers, renderthread sources could use bufferAge
    specific swap behaviours and would result in partially missing
    display redraws upon animations and rotated screens,
    for instance flashing action bars, blinking loading bars
    and half black displays in landscape rotations

Change-Id: I16fe13f0726792522e382716f8f24eccf2a27701
Signed-off-by: Adrian DC <radian.dc@gmail.com>